### PR TITLE
Added script, etc to build standalone Electron 

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "styleguide:build": "styleguidist build && mv styleguide build",
     "start": "rescripts start",
     "build": "rescripts build && yarn styleguide:build",
+    "electron:build": "react-scripts build",
     "deploy": "git push",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",

--- a/public/electron-package.json
+++ b/public/electron-package.json
@@ -40,7 +40,7 @@
   ],
   "author": {
     "name": "unfoldingword.org",
-    "email": "finance@unfoldingword.org"
+    "email": "dev@unfoldingword.org"
   },
   "license": "MIT"
 }

--- a/public/electron-package.json
+++ b/public/electron-package.json
@@ -1,0 +1,46 @@
+{
+  "name": "tc-create-app",
+  "version": "0.9.0-beta.9",
+  "description": "Create Translation Core",
+  "main": "index.js",
+  "homepage": "https://create.translationcore.com/",
+  "scripts": {
+    "electron:start": "electron ./",
+    "pack": "electron-builder --dir",
+    "dist": "electron-builder"
+  },
+  "build": {
+    "appId": "org.unfoldingword.tc-create-app",
+    "linux": {
+      "target": "deb",
+      "icon": "app/glts_logo_white.png",
+      "maintainer": "unfoldingword.org"
+    },
+    "win": {
+      "target": "nsis",
+      "icon": "app/glts_logo_white.png"
+    },
+    "mac": {
+      "category": "public.app-category.utilities",
+      "target": "default",
+      "icon": "app/glts_logo_white.png"
+    }
+  },
+  "dependencies": {
+    "@capacitor/electron": "^1.5.1",
+    "electron-is-dev": "^1.1.0"
+  },
+  "devDependencies": {
+    "electron": "^8.1.1",
+    "electron-builder": "^22.4.1"
+  },
+  "keywords": [
+    "capacitor",
+    "electron"
+  ],
+  "author": {
+    "name": "unfoldingword.org",
+    "email": "finance@unfoldingword.org"
+  },
+  "license": "MIT"
+}

--- a/scripts/build-electron.sh
+++ b/scripts/build-electron.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 CLONETARGET="build-electron"
+REPOGIT=git@github.com:mandolyte/tc-create-app.git
 
 if [ "$1x" != "x" ] 
 then
@@ -26,7 +27,6 @@ echo Clone the repo
 echo Start at `date`
 echo +-------------------------------------------------------------+
 
-REPOGIT=git@github.com:unfoldingWord/tc-create-app.git
 git clone $REPOGIT $CLONETARGET
 
 echo +-------------------------------------------------------------+

--- a/scripts/build-electron.sh
+++ b/scripts/build-electron.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+
+CLONETARGET="tca-electron"
+
+if [ "$1x" != "x" ] 
+then
+	CLONETARGET=$1
+else 
+	echo Usage: sh ${CLONETARGET}.sh targetdir
+	echo where targetdir is git clone folder to create
+	echo For example, sh ${CLONETARGET}.sh myapp
+	exit
+fi
+
+if [ -d "$CLONETARGET" ]; then
+	echo +-------------------------------------------------------------+
+	echo The clone target  $CLONETARGET already exits 
+	echo Fatal Error!                                 
+	echo +-------------------------------------------------------------+
+	exit
+fi
+
+echo +-------------------------------------------------------------+
+echo The clone target is $CLONETARGET 
+echo Clone the repo
+echo Start at `date`
+echo +-------------------------------------------------------------+
+
+REPOGIT=git@github.com:unfoldingWord/tc-create-app.git
+git clone $REPOGIT $CLONETARGET
+
+echo +-------------------------------------------------------------+
+echo Switch to cloned folder
+
+cd $CLONETARGET 
+
+ROOT=`pwd`
+echo Root folder of project is $ROOT
+echo Get dependencies with yarn
+echo +-------------------------------------------------------------+
+
+yarn install
+
+echo +-------------------------------------------------------------+
+echo Build the react web app with yarn build
+echo +-------------------------------------------------------------+
+
+rescripts build
+
+echo +-------------------------------------------------------------+
+echo Add capacitor
+echo +-------------------------------------------------------------+
+
+yarn add --dev @capacitor/core @capacitor/cli
+
+echo +-------------------------------------------------------------+
+echo Initialize capacitor
+echo +-------------------------------------------------------------+
+APPNAME="tc-create-app"
+APPID="org.unfoldingword.TcCreateApp"
+npx cap init --web-dir "build" $APPNAME $APPID
+
+echo +-------------------------------------------------------------+
+echo Define target platform with capacitor
+echo +-------------------------------------------------------------+
+
+npx cap add electron
+
+echo +-------------------------------------------------------------+
+echo Fix electron package.json, from public/electron-package.json
+echo a. change name
+echo b. change description
+echo c. supply author
+echo d. replace capacitor splash png with ours
+
+cd $ROOT
+cp ./public/electron-package.json ./electron/package.json
+cp ./public/glts_logo_white.png ./electron/splash_assets/splash.png
+
+echo +-------------------------------------------------------------+
+echo Fix electron index.html
+echo +-------------------------------------------------------------+
+
+cd $ROOT/electron/app 
+sed \
+	-e "s#/favicon#./favicon#g" \
+	-e "s#/manifest#./manifest#g" \
+	-e "s#/static#./static#g" \
+	< index.html > x && mv x index.html
+cd $ROOT 
+
+echo +-------------------------------------------------------------+
+echo Copy index.js to app folder
+echo +-------------------------------------------------------------+
+
+cd $ROOT/electron/
+cp index.js app
+cd $ROOT 
+
+
+
+echo +-------------------------------------------------------------+
+echo Key Concepts
+echo 1. At this point, the electron app is in the electron folder.
+echo 2. It is completely separated from the React web app.
+echo 3. It has its own package.json file
+echo 4. You can start it: yarn electron:start
+echo 5. All packaging work needs to be done inside this folder!
+echo +-------------------------------------------------------------+
+
+
+echo +-------------------------------------------------------------+
+echo Install electron and electron-builder
+echo +-------------------------------------------------------------+
+
+cd $ROOT/electron
+yarn add --dev electron
+yarn add --dev electron-builder 
+
+echo +-------------------------------------------------------------+
+echo Run packager 
+echo +-------------------------------------------------------------+
+
+$ROOT/electron/node_modules/.bin/electron-builder
+
+echo +-------------------------------------------------------------+
+echo Done at `date`
+echo +-------------------------------------------------------------+

--- a/scripts/build-electron.sh
+++ b/scripts/build-electron.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 CLONETARGET="build-electron"
-REPOGIT=git@github.com:mandolyte/tc-create-app.git
+REPOGIT=git@github.com:unfoldingword/tc-create-app.git
 
 if [ "$1x" != "x" ] 
 then

--- a/scripts/build-electron.sh
+++ b/scripts/build-electron.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CLONETARGET="tca-electron"
+CLONETARGET="build-electron"
 
 if [ "$1x" != "x" ] 
 then
@@ -45,7 +45,7 @@ echo +-------------------------------------------------------------+
 echo Build the react web app with yarn build
 echo +-------------------------------------------------------------+
 
-rescripts build
+yarn electron:build
 
 echo +-------------------------------------------------------------+
 echo Add capacitor


### PR DESCRIPTION
Change summary:
- added two new files: one in scripts folder and one in public
- added an entry to `package.json` to create an optimized build in folder `./build`

If you copy out the script `build-electron.sh` and run on local machine, it will clone my fork (at present, anyway) and build an electron executable for whatever platform you are running it on.

*NOTE:* Only tested on Windows as of right now.

The script can be used to guide creation of a Github Action workflow... but that's another task and it needs some discussion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-create-app/105)
<!-- Reviewable:end -->
