### PR TITLE
PR for issue 109 (re-do)

### DIFF
--- a/src/components/translatable/Translatable.js
+++ b/src/components/translatable/Translatable.js
@@ -103,6 +103,8 @@ function Translatable() {
             <DataTable {...translatableProps} />
           </ResourcesContextProvider>
         );
+      } else {
+        _translatable = <h3 style={{ 'text-align': 'center'}} >Unsupported File. Please select .md or .tsv files.</h3>;
       }
     } 
     return _translatable;


### PR DESCRIPTION
Previous change for 109 was lost due to another change in same area of code for the hooks and contexts features.

This restores the missing "else" statement to show the "unsupported file type" message when something other than TSV or MD files are selected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-create-app/147)
<!-- Reviewable:end -->
