### PR TITLE
Fix QA URL

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
 [build]
   [build.environment]
   # Effectively will be used for the development environment only
-    REACT_APP_DOOR43_SERVER_URL = "https://bg.door43.org"
+    REACT_APP_DOOR43_SERVER_URL = "https://qa.door43.org"
     CYPRESS_CACHE_FOLDER = "./node_modules/CypressBinary"
     
 [context.production]
@@ -13,5 +13,5 @@
 
 [context.deploy-preview]
   [context.deploy-preview.environment]
-    REACT_APP_DOOR43_SERVER_URL = "https://bg.door43.org"
+    REACT_APP_DOOR43_SERVER_URL = "https://qa.door43.org"
     CYPRESS_CACHE_FOLDER = "./node_modules/CypressBinary"


### PR DESCRIPTION
The bg alias is deprecated, please use qa.door43.org

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/tc-create-app/862)
<!-- Reviewable:end -->
